### PR TITLE
Fix eval_abx from pre computed option

### DIFF
--- a/cpc/eval/eval_ABX.py
+++ b/cpc/eval/eval_ABX.py
@@ -155,7 +155,10 @@ def parse_args(argv):
 
     parser_db = subparsers.add_parser('from_pre_computed')
     update_base_parser(parser_db)
-    parser_db.add_argument('path_features', type=str,
+    parser_db.add_argument('path_item_file', type=str,
+                           help="Path to the ABX .item file containing "
+                           "the triplets labels")
+    parser_db.add_argument('path_dataset', type=str,
                            help="Path to pre-computed torch features (.pt)")
     parser_db.add_argument('--file_extension', type=str,
                            default='.pt', help='Extension of each feature '


### PR DESCRIPTION
The" from_pre_computed" option of eval_abx didn't work. This PR fixes the problem but doesn't change the anything for the "from_checkpoint" option.